### PR TITLE
Extend FAQ with link to contact person google doc

### DIFF
--- a/_includes/faq.html
+++ b/_includes/faq.html
@@ -70,7 +70,7 @@
                               <dd>Wenn du mit der Deutschen Post verschickst, brauchst du eine 70ct Briefmarke. Oft geht es am Briefmarkenautomaten am schnellsten.</dd>
 
                               <dt>Woher stammen die Adressen und Telefonnummern der Ansprechpartner?</dt>
-                              <dd>Es gab anscheinend bislang keine fertige Liste aller Landrät*innen und Oberbürgermeister*innen. Daher haben wir in den letzten Wochen über 400 Landkreis- und Städtewebseiten besucht und Namen, Adressen und Telefonnummern von Hand eingesammelt. <!-- Diese Daten wandern nun in den nächsten Wochen nach <a href="https://www.wikidata.org">Wikidata</a>, dem freien Informationsspeicher hinter der Wikipedia. --></dd>
+                              <dd>Es gab anscheinend bislang keine fertige Liste aller Landrät*innen und Oberbürgermeister*innen. Daher haben wir in den letzten Wochen über 400 Landkreis- und Städtewebseiten besucht und Namen, Adressen und Telefonnummern von Hand eingesammelt (<a href="https://docs.google.com/spreadsheets/d/1MNPMJGdsoKYNwmdMAE3R8rZSO0B5jxrtlvadrFfMyQ8/pubhtml">zum Dokument</a>). <!-- Diese Daten wandern nun in den nächsten Wochen nach <a href="https://www.wikidata.org">Wikidata</a>, dem freien Informationsspeicher hinter der Wikipedia. --></dd>
 
                               <dt>Die Adresse/Telefonnummer stimmt nicht.</dt>
                               <dd>Oh, dann ist uns entweder beim Einsammeln von den Landkreis-/Städtewebseiten ein fehler unterlaufen, oder auf der jeweiligen Webseite standen veraltete Daten. <a href="mailto:info@rettedeinennahverkehr.de">Schicke uns eine E-Mail</a>, dann korrigieren wir es schnellstmöglich.</dd>


### PR DESCRIPTION
It just feels natural and web-like to link to the document that is talked about, so no one needs to read the sourcecode to find it. Once there is a better storage place / link-target.