### PR TITLE
More detailed success-history in timeline

### DIFF
--- a/_includes/how.html
+++ b/_includes/how.html
@@ -62,7 +62,17 @@
                                     <h4 class="subheading">Erste Verkehrsverbünde öffnen ihre Daten</h4>
                                 </div>
                                 <div class="timeline-body">
-                                    <p class="text-muted">Die Beispiele überzeugten – <a href="https://okfn.de/en/blog/2012/09/open-data-nahverkehr-berlin-brandenburg-update-zum-status-quo-und-den-entwicklungen/">2012 öffnete der Verkehrsverbund Berlin-Brandenburg seine Fahrpläne</a>, <a href="https://www.swu.de/privatkunden/swu-nahverkehr/gtfs-daten.html">2013 folgten die Stadtwerke Ulm</a>, <a href="https://opendata.rnv-online.de/datensaetze/gtfs-general-transit-feed-specification/resource/rnv-gtfs">2016 zog der rnv nach</a>. Der erste Aufschlag ist gemacht – welcher Verbund traut sich als nächstes?</p>
+                                    <p class="text-muted">
+                                        2012-09: <a href="https://okfn.de/en/blog/2012/09/open-data-nahverkehr-berlin-brandenburg-update-zum-status-quo-und-den-entwicklungen/">VBB Verkehrsverbund Berlin-Brandenburg</a>
+                                        <br>
+                                        2013-03: <a href="https://www.swu.de/privatkunden/swu-nahverkehr/gtfs-daten.html">SWU Stadtwerke Ulm</a>
+                                        <br>
+                                        2016-03: <a href="https://opendata.rnv-online.de/datensaetze/gtfs-general-transit-feed-specification/resource/rnv-gtfs">rnv Rhein-Neckar-Verkehr</a>
+                                        <br>
+                                        2017-03: <a href="https://offenedaten-koeln.de/dataset/vrs-verkehrsdaten-gtfs">VRS Verkehrsverbund Rhein-Sieg</a>
+                                        <br>
+                                        Der erste Aufschlag ist gemacht – welcher Verbund traut sich als nächstes?
+                                    </p>
                                 </div>
                             </div>
                         </li>

--- a/_includes/how.html
+++ b/_includes/how.html
@@ -67,7 +67,7 @@
                                         <br>
                                         2013-03: <a href="https://www.swu.de/privatkunden/swu-nahverkehr/gtfs-daten.html">SWU Stadtwerke Ulm</a>
                                         <br>
-                                        2016-03: <a href="https://opendata.rnv-online.de/datensaetze/gtfs-general-transit-feed-specification/resource/rnv-gtfs">rnv Rhein-Neckar-Verkehr</a>
+                                        2016-04: <a href="https://opendata.rnv-online.de/datensaetze/gtfs-general-transit-feed-specification/resource/rnv-gtfs">rnv Rhein-Neckar-Verkehr</a>
                                         <br>
                                         2017-03: <a href="https://offenedaten-koeln.de/dataset/vrs-verkehrsdaten-gtfs">VRS Verkehrsverbund Rhein-Sieg</a>
                                         <br>


### PR DESCRIPTION
Extend the timeline with a list of dates and links to underline the successes. This is also a good place to link to the pages that have more information about each data sets.

I think its a good idea to collect the time and info about each change somewhere, so there is a complete timeline and some statistics later on.

This place on the webpage will not work for all entries, but for the next 10 or so it should be fine.

It is one more place to update, of course, but IMO its worth the additional work.

This is what it will look like:
<img width="634" alt="bildschirmfoto 2017-04-17 um 14 30 15" src="https://cloud.githubusercontent.com/assets/111561/25088910/773bcf1a-237a-11e7-87b4-be65147c3320.png">

Sidenote: Another place to link to the data sets would be the success-message of the zip-search, eg. "Oh! In diesem Landkreis bietet der AVV bereits offene Fahrplandaten an. Das ist klasse!". But then again that would only be interesting for developers who can find the data easily via google. And also the timeline shows more of a success (and the a lack of participation by the "Verbünde") than the success message would. So in the end it's not worth the effort IMO.

PS: The month for "rnv" is guessed from a date on http://www.gtfs-data-exchange.com/meta/5687256610242560 since I could not find a launch date anywhere else.
