### PR TITLE
add links for data sources in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,7 @@ Offene Fahrplandaten statt vernagelter Systeme.
 Diese Seite basiert auf [jekyll](https://jekyllrb.com).
 
 Für die Auflösung PLZ -> Ansprechpartner, passieren zwei Schritte:
-* PLZ zu Landkreiskennzahl (adminCode3) über die `data/plz2lkr.csv` (Q: [http://opendata.blattspinat.com](http://opendata.blattspinat.com))
-* Nachschlagen von Ansprechpartner, Verkehrsverbund, etc. durch [tabletop](https://github.com/jsoma/tabletop) in Google Sheets
+* PLZ zu Landkreiskennzahl (adminCode3) über die [`data/plz2lkr.csv`](data/plz2lkr.csv) (Q: [http://opendata.blattspinat.com](http://opendata.blattspinat.com))
+* Nachschlagen von Ansprechpartner, Verkehrsverbund, etc. durch [tabletop](https://github.com/jsoma/tabletop) in [Google Sheets](https://docs.google.com/spreadsheets/d/1MNPMJGdsoKYNwmdMAE3R8rZSO0B5jxrtlvadrFfMyQ8/pubhtml)
 
 Die Daten stammen aus der OpenStreetMap, GeoBasis-DE / BKG 2015, Wikidata und manueller Sammlung aus Stadt-/Landkreiswebsites.
-


### PR DESCRIPTION
Makes it easer for people (like me 😄) who come here looking for a machine-readable list of transport agencies in Germany and their contact data.